### PR TITLE
Xvfb dependency

### DIFF
--- a/resources/rosdep/handcrafted_common.yaml
+++ b/resources/rosdep/handcrafted_common.yaml
@@ -28,3 +28,6 @@ libgbm-dev:
 
 uvdar_core:
   ubuntu: [ros-noetic-uvdar-core]
+
+xvfb:
+  ubuntu: [xvfb]


### PR DESCRIPTION
Adding a map for dependency on xvfb - a virtual framebuffer to address the buildfarm's unavailability of display